### PR TITLE
Centralized plugin loading that behaves just like click.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
 build/
 develop-eggs/
 dist/
@@ -52,3 +53,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# PyCharm IDE
+.idea/

--- a/README.rst
+++ b/README.rst
@@ -60,3 +60,41 @@ On the command line it works like this.
     ^^{'type': 'Feature', 'id': '2'}
 
 In this example, ``^^`` represents 0x1e.
+
+
+Plugins
+-------
+
+``cligj`` can also facilitate loading external `click-based <http://click.pocoo.org/4/>`_
+plugins via `setuptools entry points <https://pythonhosted.org/setuptools/setuptools.html#dynamic-discovery-of-services-and-plugins>`_.
+The ``cligj.plugins`` module contains a special ``group()`` decorator that behaves exactly like
+``click.group()`` except that it offers the opportunity load plugins and attach them to the
+group as it is istantiated.
+
+.. code-block:: python
+
+    from pkg_resources import iter_entry_points
+
+    import cligj.plugins
+    import click
+
+    @cligj.plugins.group(plugins=iter_entry_points('module.entry_points'))
+    def cli():
+
+        """A CLI application."""
+
+        pass
+
+    @cli.command()
+    @click.argument('arg')
+    def printer(arg):
+
+        """Print arg."""
+
+        click.echo(arg)
+
+    @cli.group(plugins=iter_entry_points('other_module.more_plugins'))
+    def plugins():
+
+        """A sub-group that contains plugins from a different module."""
+        pass

--- a/cligj/plugins.py
+++ b/cligj/plugins.py
@@ -94,6 +94,8 @@ class BrokenCommand(click.Command):
             Name of command.
         """
 
+        util_name = os.path.basename(sys.argv and sys.argv[0] or __file__)
+
         click.Command.__init__(self, name)
         self.help = (
             "Warning: entry point could not be loaded. Contact "
@@ -101,7 +103,7 @@ class BrokenCommand(click.Command):
             + traceback.format_exc())
         self.short_help = (
             "Warning: could not load plugin. See `%s %s --help`."
-            % (sys.argv and sys.argv[0] or __file__, self.name))
+            % (util_name, self.name))
 
     def invoke(self, ctx):
 

--- a/cligj/plugins.py
+++ b/cligj/plugins.py
@@ -154,8 +154,18 @@ class Group(click.Group):
 def group(plugins=None, **kwargs):
 
     """
-    A special group decorator that behaves exactly like `click.group()` except
-    that plugins structured as setuptools entry points optionally be loaded first.
+    A special group decorator that behaves exactly like `click.group()` but
+    allows for additional plugins to be loaded.
+
+    Example:
+
+        >>> import cligj.plugins
+        >>> from pkg_resources import iter_entry_points
+        >>> plugins = iter_entry_points('module.entry_points')
+        >>> @cligj.plugins.group(plugins=plugins)
+        ... def cli():
+        ...    '''A CLI aplication'''
+        ...    pass
 
     Plugins that raise an exception on load are caught and converted to an
     instance of `BrokenCommand()`, which has better error handling and prevents
@@ -165,6 +175,8 @@ def group(plugins=None, **kwargs):
 
     Parameters
     ----------
+    plugins : iter
+        An iterable that produces one entry point per iteration.
     kwargs : **kwargs
         Additional arguments for `click.Group()`.
     """

--- a/cligj/plugins.py
+++ b/cligj/plugins.py
@@ -1,0 +1,191 @@
+"""
+Common components required to enable setuptools plugins.
+
+In general the components defined here are slightly modified or subclassed
+versions of core click components.  This is required in order to insert code
+that loads entry points when necessary while still maintaining a simple API
+is only slightly different from the click API.  Here's how it works:
+
+When defining a main commandline group:
+
+    >>> import click
+    >>> @click.group()
+    ... def cli():
+    ...    '''A commandline interface.'''
+    ...    pass
+
+The `click.group()` decorator turns `cli()` into an instance of `click.Group()`.
+Subsequent commands hang off of this group:
+
+    >>> @cli.command()
+    ... @click.argument('val')
+    ... def printer(val):
+    ...    '''Print a value.'''
+    ...    click.echo(val)
+
+At this point the entry points, which are just instances of `click.Command()`,
+can be added to the main group with:
+
+    >>> from pkg_resources import iter_entry_points
+    >>> for ep in iter_entry_points('module.commands'):
+    ...    cli.add_command(ep.load())
+
+This works but its not very Pythonic, is vulnerable to typing errors, must be
+manually updated if a better method is discovered, and most importantly, if an
+entry point throws an exception on completely crashes the group the command is
+attached to.
+
+A better time to load the entry points is when the group they will be attached
+to is instantiated.  This requires slight modifications to the `click.group()`
+decorator and `click.Group()` to let them load entry points as needed.  If the
+modified `group()` decorator is used on the same group like this:
+
+    >>> from pkg_resources import iter_entry_points
+    >>> import cligj.plugins
+    >>> @cligj.plugins.group(plugins=iter_entry_points('module.commands'))
+    ... def cli():
+    ...    '''A commandline interface.'''
+    ...    pass
+
+Now the entry points are loaded before the normal `click.group()` decorator
+is called, except it returns a modified `Group()` so if we hang another group
+off of `cli()`:
+
+    >>> @cli.group(plugins=iter_entry_points('other_module.commands'))
+    ... def subgroup():
+    ...    '''A subgroup with more plugins'''
+    ...    pass
+
+We can register additional plugins in a sub-group.
+
+Catching broken plugins is done in the modified `group()` which attaches instances
+of `BrokenCommand()` to the group instead of instances of `click.Command()`.  The
+broken commands have special help messages and override `click.Command.invoke()`
+so the user gets a useful error message with a traceback if they attempt to run
+the command or use `--help`.
+"""
+
+
+import os
+import sys
+import traceback
+
+import click
+
+
+class BrokenCommand(click.Command):
+
+    """
+    Rather than completely crash the CLI when a broken plugin is loaded, this
+    class provides a modified help message informing the user that the plugin is
+    broken and they should contact the owner.  If the user executes the plugin
+    or specifies `--help` a traceback is reported showing the exception the
+    plugin loader encountered.
+    """
+
+    def __init__(self, name):
+
+        """
+        Define the special help messages after instantiating `click.Command()`.
+
+        Parameters
+        ----------
+        name : str
+            Name of command.
+        """
+
+        click.Command.__init__(self, name)
+        self.help = (
+            "Warning: entry point could not be loaded. Contact "
+            "its author for help.\n\n\b\n"
+            + traceback.format_exc())
+        self.short_help = (
+            "Warning: could not load plugin. See `%s %s --help`."
+            % (sys.argv and sys.argv[0] or __file__, self.name))
+
+    def invoke(self, ctx):
+
+        """
+        Print the error message instead of doing nothing.
+
+        Parameters
+        ----------
+        ctx : click.Context
+            Required for click.
+        """
+
+        click.echo(self.help, color=ctx.color)
+        ctx.exit()
+
+
+class Group(click.Group):
+
+    """
+    A subclass of `click.Group()` that returns the modified `group()` decorator
+    when `Group.group()` is called.  Used by the modified `group()` decorator.
+    So many groups...
+
+    See the main docstring in this file for a full explanation.
+    """
+
+    def __init__(self, **kwargs):
+        click.Group.__init__(self, **kwargs)
+
+    def group(self, *args, **kwargs):
+
+        """
+        Return the modified `group()` rather than `click.group()`.  This
+        gives the user an opportunity to assign entire groups of plugins
+        to their own subcommand group.
+
+        See the main docstring in this file for a full explanation.
+        """
+
+        def decorator(f):
+            cmd = group(*args, **kwargs)(f)
+            self.add_command(cmd)
+            return cmd
+
+        return decorator
+
+
+def group(plugins=None, **kwargs):
+
+    """
+    A special group decorator that behaves exactly like `click.group()` except
+    that plugins structured as setuptools entry points optionally be loaded first.
+
+    Plugins that raise an exception on load are caught and converted to an
+    instance of `BrokenCommand()`, which has better error handling and prevents
+    broken plugins from taking crashing the CLI.
+
+    See the main docstring in this file for a full explanation.
+
+    Parameters
+    ----------
+    kwargs : **kwargs
+        Additional arguments for `click.Group()`.
+    """
+
+    def decorator(f):
+
+        kwargs.setdefault('cls', Group)
+        grp = click.group(**kwargs)(f)
+
+        if plugins is not None:
+            for entry_point in plugins:
+                try:
+                    grp.add_command(entry_point.load())
+
+                except Exception:
+                    # Catch this so a busted plugin doesn't take down the CLI.
+                    # Handled by registering a dummy command that does nothing
+                    # other than explain the error.
+                    if os.environ.get('CLIGJ_HONESTLY'):
+                        broken_name = entry_point.name + u'\U0001F4A9'
+                    else:
+                        broken_name = entry_point.name + u'\u2020'
+                    grp.add_command(BrokenCommand(broken_name))
+        return grp
+
+    return decorator

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# Do not delete this file.  It makes the tests directory behave like a Python
+# module, which is required to manually register and test plugins.

--- a/tests/broken_plugins.py
+++ b/tests/broken_plugins.py
@@ -1,0 +1,20 @@
+"""
+We detect plugins that throw an exception on import, so just throw an exception
+to mimic a problem.
+"""
+
+
+import click
+
+
+@click.command()
+def something(arg):
+    click.echo('passed')
+
+
+raise Exception('I am a broken plugin.  Send help.')
+
+
+@click.command()
+def after():
+    pass

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -33,7 +33,9 @@ def cmd2(arg):
 # which calls `dist.requires()` and the `cligj.plugins.group()` decorator
 # doesn't allow us to change this.  Because we are manually registering these
 # plugins the `dist` attribute is `None` so we can just create a stub that
-# always returns an empty list since we don't have any requirements.
+# always returns an empty list since we don't have any requirements.  A full
+# `pkg_resources.Distribution()` instance is not needed because there isn't
+# a package installed anywhere.
 class DistStub(object):
     def requires(self, *args):
         return []

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,80 @@
+"""Unittests for ``cligj.plugins``."""
+
+
+from pkg_resources import EntryPoint
+from pkg_resources import iter_entry_points
+from pkg_resources import working_set
+
+import click
+
+import cligj.plugins
+
+
+# Create a few CLI commands for testing
+@click.command()
+@click.argument('arg')
+def printer(arg):
+
+    """
+    Printit!
+    """
+
+    click.echo('passed')
+
+@click.command()
+@click.argument('arg')
+def square(arg):
+
+    """
+    Square it!
+    """
+
+    click.echo('passed')
+
+
+# Manually register plugins in an entry point and put broken plugins in a
+# different entry point.
+
+# The `DistStub()` class gets around an exception that is raised when
+# `entry_point.load()` is called.  By default `load()` has `requires=True`
+# which calls `dist.requires()` and the `cligj.plugins.group()` decorator
+# doesn't allow us to change this.  Because we are manually registering these
+# plugins the `dist` attribute is `None` so we can just create a stub that
+# always returns an empty list since we don't have any requirements.
+class DistStub(object):
+    def requires(self, *args):
+        return []
+
+working_set.by_key['cligj']._ep_map = {
+    'cligj.test_plugins': {
+        'printer': EntryPoint.parse(
+            'printer=tests.test_plugins:printer', dist=DistStub()),
+        'square': EntryPoint.parse(
+            'square=tests.test_plugins:square', dist=DistStub())
+    },
+    'cligj.broken_plugins': {
+        'before': EntryPoint.parse(
+            'before=tests.broken_plugins:before', dist=DistStub()),
+        'after': EntryPoint.parse(
+            'after=tests.broken_plugins:after', dist=DistStub()),
+        'do_not_exist': EntryPoint.parse(
+            'do_not_exist=tests.broken_plugins:do_not_exist', dist=DistStub())
+    }
+}
+
+
+def test_register_and_run(runner):
+
+    @cligj.plugins.group(plugins=iter_entry_points('cligj.test_plugins'))
+    def cli():
+        pass
+
+    # Execute without any calling a sub-command to get the help message
+    result = runner.invoke(cli)
+    assert result.exit_code is 0
+
+    # Execute each subcommand
+    for ep in iter_entry_points('cligj.test_plugins'):
+        cmd_result = runner.invoke(cli, [ep.name, 'something'])
+        assert cmd_result.exit_code is 0
+        assert cmd_result.output.strip() == 'passed'

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -15,21 +15,13 @@ import cligj.plugins
 @click.command()
 @click.argument('arg')
 def cmd1(arg):
-
-    """
-    Printit!
-    """
-
+    """Test command 1"""
     click.echo('passed')
 
 @click.command()
 @click.argument('arg')
 def cmd2(arg):
-
-    """
-    Square it!
-    """
-
+    """Test command 2"""
     click.echo('passed')
 
 
@@ -67,11 +59,21 @@ working_set.by_key['cligj']._ep_map = {
 # Main CLI groups - one with good plugins attached and the other broken
 @cligj.plugins.group(plugins=iter_entry_points('cligj.test_plugins'))
 def good_cli():
+    """Good CLI group."""
     pass
+
 
 @cligj.plugins.group(plugins=iter_entry_points('cligj.broken_plugins'))
 def broken_cli():
+    """Broken CLI group."""
     pass
+
+
+def test_registered():
+    # Make sure the plugins are properly registered.  If this test fails it
+    # means that some of the for loops in other tests may not be executing.
+    assert len([ep for ep in iter_entry_points('cligj.test_plugins')]) > 1
+    assert len([ep for ep in iter_entry_points('cligj.broken_plugins')]) > 1
 
 
 def test_register_and_run(runner):
@@ -103,7 +105,9 @@ def test_group_chain(runner):
     # sure both the sub-group and all the parent group's commands are present
     @good_cli.group()
     def sub_cli():
+        """Sub CLI."""
         pass
+
     result = runner.invoke(good_cli)
     assert result.exit_code is 0
     assert sub_cli.name in result.output
@@ -113,12 +117,14 @@ def test_group_chain(runner):
     # Same as above but the sub-group has plugins
     @good_cli.group(plugins=iter_entry_points('cligj.test_plugins'))
     def sub_cli_plugins():
+        """Sub CLI with plugins."""
         pass
+
     result = runner.invoke(good_cli, ['sub_cli_plugins'])
     assert result.exit_code is 0
     for ep in iter_entry_points('cligj.test_plugins'):
         assert ep.name in result.output
-    
+
     # Execute one of the sub-group's commands
     result = runner.invoke(good_cli, ['sub_cli_plugins', 'cmd1', 'something'])
     assert result.exit_code is 0


### PR DESCRIPTION
_For #2_

@sgillies I figured out how to simplify the API to the point where it behaves just like click normally does.  I think this is actually something click should be able to handle natively so we should consider submitting a pull request, although their release cycle is kinda slow we will probably have to use the cligj implementation for a while.  I'll add unittests after you review.

**How does it work?**

There's a full explanation of how this works in [`cligj.plugins.__doc__`](https://github.com/mapbox/cligj/blob/0ad8fda38b2db7ef37b6cb778d34cb2271f3db3f/cligj/plugins.py#L1-L66) but in general it works by subclassing and intercepting click components, executing the entry point loading logic, attaching commands, broken commands, or groups, and then calling the equivalent click command.  Here's a CLI interface that has a main group, a sub command, and loaded plugins:

``` python
import click
import cligj.plugins
from pkg_resources import iter_entry_points

@cligj.plugins.group(plugins=iter_entry_points('module.commands'))
def cli():

    """A CLI application."""

    pass

@cli.command()
@click.argument('val')
def printer(val):

    """Print a value."""

   click.echo(val)
```

**Extra gains**

By doing this with decorators and subclassing `click.Group()`, commands and plugins are completely modular and can be moved from group to group in any click based application.  Here's the same example from above but with all of the `rio` commands attached to a `plugins` sub-group that also has its own command:

``` python
from pkg_resources import iter_entry_points
import click
import cligj.plugins

# If any sub-groups are going to register plugins then the parent group has to come from cligj.
# This can also be done with `click.group(cls=cligj.plugins.Group())`.
# We don't want any plugins on this main group though, only the `plugins` group.
@cligj.plugins.group()
def cli():

    """A CLI application."""

    pass

@cli.command()
@click.argument('val')
def printer(val):

    """Print a value."""

   click.echo(val)

# The group returned here is the modified `cligj.plugins.Group()`
@cli.group(plugins=iter_entry_points('rasterio.rio_commands'))
def plugins():

    """rio commands"""
    pass

@plugins.command()
@click.argument('val')
def shout(val):

    """
    Print a value loudly.
    """

    click.echo(val.upper())
```

**fio & rio changes**

I have a version of Fiona [on a branch](https://github.com/geowurster/fiona/tree/plugin-reorg) that uses this plugin architecture but I haven't fully looked around to see if there are additional changes that need to happen, but the tests pass, the few commands I tested worked, and breaking plugins works properly.
1. Attaching commands to the main `cli()` on setup causes circular imports so all commands must be decorated as `click.command()`.
2. Anything in `main.py` that is imported into one of the command files must be moved elsewhere.  I dumped them in a `helper.py` in the branch but that may not be the best location.
3. `main.py` should exist only to provide an isolated entry point to the main cli group.
4. `cli.py` should be where all commands are aggregated for entry point access.

**Actions**
- [ ] Right now all the CLI commands are registered as entry points in `rasterio.rio_commands` and [users are instructed](https://github.com/sgillies/rio-plugin-example/blob/master/setup.py#L41) to register their plugins in the same place.  We will likely be saved some headaches later if `rasterio.rio_commands` is reserved for the official `rio` commands and users are instructed to register their plugins at `rasterio.rio_plugins`.  `cligj.plugins.group()` should be changed to take a string or tuple in that case.
- [ ] I think using the same syntax and object names as click is good, but it is unfortunate that cligj and click are so typographically similar.  I think referencing the cligj objects with `cligj.plugins` may help.
- [ ] Do `cli.py` and `main.py` have an intended use?  Since the individual click commands can't be attached to the main group maybe we want to have a `commands.py` where we aggregate?
- [ ] Where should helper functions live that are currently in `main.py`?  In the branch I just created a `helper.py` file to get them out of the way.
