### PR TITLE
Deprecate cligj.plugins in favor of click-plugins.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,8 @@ In this example, ``^^`` represents 0x1e.
 Plugins
 -------
 
+**DEPRECATED:** Use `click-plugins <https://github.com/click-contrib/click-plugins>`_ instead.
+
 ``cligj`` can also facilitate loading external `click-based <http://click.pocoo.org/4/>`_
 plugins via `setuptools entry points <https://pythonhosted.org/setuptools/setuptools.html#dynamic-discovery-of-services-and-plugins>`_.
 The ``cligj.plugins`` module contains a special ``group()`` decorator that behaves exactly like

--- a/cligj/plugins.py
+++ b/cligj/plugins.py
@@ -69,8 +69,15 @@ the command or use `--help`.
 import os
 import sys
 import traceback
+import warnings
 
 import click
+
+
+warnings.warn(
+    "cligj.plugins has been deprecated in favor of click-plugins: "
+    "https://github.com/click-contrib/click-plugins",
+    FutureWarning, stacklevel=2)
 
 
 class BrokenCommand(click.Command):


### PR DESCRIPTION
Closes #6.

@sgillies ready for review.
