### PR TITLE
iter_features and normalize_feature_inputs improvements

### DIFF
--- a/cligj/__init__.py
+++ b/cligj/__init__.py
@@ -16,6 +16,7 @@ files_in_arg = click.argument(
     required=True,
     metavar="INPUTS...")
 
+
 # Multiple files, last of which is an output file.
 files_inout_arg = click.argument(
     'files',
@@ -24,9 +25,11 @@ files_inout_arg = click.argument(
     required=True,
     metavar="INPUTS... OUTPUT")
 
+
 # Features input
 # Accepts multiple representations of GeoJSON features
-# Returns the input data as an iterable of GeoJSON Feature-like dictionaries
+# Returns the input data as an iterable of GeoJSON Feature-like
+# dictionaries.
 features_in_arg = click.argument(
     'features',
     nargs=-1,

--- a/cligj/__init__.py
+++ b/cligj/__init__.py
@@ -26,8 +26,7 @@ files_inout_arg = click.argument(
     metavar="INPUTS... OUTPUT")
 
 
-# Features input
-# Accepts multiple representations of GeoJSON features
+# Features from files, command line args, or stdin.
 # Returns the input data as an iterable of GeoJSON Feature-like
 # dictionaries.
 features_in_arg = click.argument(

--- a/cligj/features.py
+++ b/cligj/features.py
@@ -54,7 +54,7 @@ def iter_features(geojsonfile, func=None):
     func: function, optional
         A function that will be applied to each extracted feature. It
         takes a feature object and may return a replacement feature or
-        None – in which case iter_features does not yield.
+        None -- in which case iter_features does not yield.
     """
     func = func or (lambda x: x)
     first_line = next(geojsonfile)

--- a/cligj/features.py
+++ b/cligj/features.py
@@ -54,7 +54,7 @@ def iter_features(geojsonfile, func=None):
     func: function, optional
         A function that will be applied to each extracted feature. It
         takes a feature object and may return a replacement feature or
-        None -- in which case iter_features does not yield.
+        None -- in which case iter_features does not yield.
     """
     func = func or (lambda x: x)
     first_line = next(geojsonfile)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -46,7 +46,14 @@ def _geoms(features):
 
 
 def test_featurecollection_file(expected_features):
-    features = normalize_feature_inputs(None, 'features', ["tests/twopoints.geojson"])
+    features = normalize_feature_inputs(
+        None, 'features', ["tests/twopoints.geojson"])
+    assert _geoms(features) == _geoms(expected_features)
+
+
+def test_featurecollection_pretty_file(expected_features):
+    features = normalize_feature_inputs(
+        None, 'features', ["tests/twopoints-pretty.json"])
     assert _geoms(features) == _geoms(expected_features)
 
 
@@ -57,7 +64,8 @@ def test_featurecollection_stdin(expected_features):
 
 
 def test_featuresequence(expected_features):
-    features = normalize_feature_inputs(None, 'features', ["tests/twopoints_seq.txt"])
+    features = normalize_feature_inputs(
+        None, 'features', ["tests/twopoints_seq.txt"])
     assert _geoms(features) == _geoms(expected_features)
 
 # TODO test path to sequence files fail
@@ -69,7 +77,8 @@ def test_featuresequence_stdin(expected_features):
 
 
 def test_singlefeature(expected_features):
-    features = normalize_feature_inputs(None, 'features', ["tests/onepoint.geojson"])
+    features = normalize_feature_inputs(
+        None, 'features', ["tests/onepoint.geojson"])
     assert _geoms(features) == _geoms([expected_features[0]])
 
 
@@ -80,7 +89,8 @@ def test_singlefeature_stdin(expected_features):
 
 
 def test_featuresequencers(expected_features):
-    features = normalize_feature_inputs(None, 'features', ["tests/twopoints_seqrs.txt"])
+    features = normalize_feature_inputs(
+        None, 'features', ["tests/twopoints_seqrs.txt"])
     assert _geoms(features) == _geoms(expected_features)
 
 

--- a/tests/twopoints-pretty.json
+++ b/tests/twopoints-pretty.json
@@ -1,0 +1,85 @@
+{
+    "features": [
+        {
+            "bbox": [
+                -122.9292140099711,
+                45.37948199034149,
+                -122.44106199104115,
+                45.858097009742835
+            ],
+            "center": [
+                -122.7282,
+                45.5801
+            ],
+            "context": [
+                {
+                    "id": "postcode.2503633822",
+                    "text": "97203"
+                },
+                {
+                    "id": "region.3470299826",
+                    "text": "Oregon"
+                },
+                {
+                    "id": "country.4150104525",
+                    "short_code": "us",
+                    "text": "United States"
+                }
+            ],
+            "geometry": {
+                "coordinates": [
+                    -122.7282,
+                    45.5801
+                ],
+                "type": "Point"
+            },
+            "id": "place.42767",
+            "place_name": "Portland, Oregon, United States",
+            "properties": {},
+            "relevance": 0.999,
+            "text": "Portland",
+            "type": "Feature"
+        },
+        {
+            "bbox": [
+                -121.9779540096568,
+                43.74737999114854,
+                -120.74788099000016,
+                44.32812500969035
+            ],
+            "center": [
+                -121.3153,
+                44.0582
+            ],
+            "context": [
+                {
+                    "id": "postcode.3332732485",
+                    "text": "97701"
+                },
+                {
+                    "id": "region.3470299826",
+                    "text": "Oregon"
+                },
+                {
+                    "id": "country.4150104525",
+                    "short_code": "us",
+                    "text": "United States"
+                }
+            ],
+            "geometry": {
+                "coordinates": [
+                    -121.3153,
+                    44.0582
+                ],
+                "type": "Point"
+            },
+            "id": "place.3965",
+            "place_name": "Bend, Oregon, United States",
+            "properties": {},
+            "relevance": 0.999,
+            "text": "Bend",
+            "type": "Feature"
+        }
+    ],
+    "type": "FeatureCollection"
+}


### PR DESCRIPTION
In `iter_features()` I've clarified the intent, added a per-feature callback function, and eliminated some superfluous assignments.

In `normalize_feature_inputs()` I've done the same and added a missing test.

With these changes, we can eliminate the iter_features implementation in Fiona.
