### PR TITLE
Include tests in sdists and license in sdists and wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include CHANGES.txt
+include LICENSE
+
+graft tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
The terms of the BSD license require all copies of the program include the license.  The tests are used by downstream packagers to make sure everything is working correctly.