### PR TITLE
Add github actions to the test platform

### DIFF
--- a/.github/workflows/click-releases.yml
+++ b/.github/workflows/click-releases.yml
@@ -1,0 +1,44 @@
+name: Click release package
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install -e .
+
+    - name: Test with click latest release
+      run: |
+        pip install click --upgrade
+        pytest -v
+
+    - name: Test with click==8.0.0
+      run: |
+        pip install click==8.0.0 --upgrade
+        pytest -v
+
+    - name: Test with click==7.0.0
+      run: |
+        pip install click==7.0.0 --upgrade
+        pytest -v

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,6 +29,9 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest coveralls pytest-cov
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Install cligj
+      run: |
+        pip install -e .  
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest coveralls
+        python -m pip install flake8 pytest coveralls pytest-cov
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python package
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest coveralls
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest --cov cligj --cov-report term-missing

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ sudo: false
 language: python
 python:
   - "3.6"
-  - "3.7"
   - "3.8"
+  - "3.9"
 install:
-  - "pip install coveralls==3.2.0"
+  - "pip install python-coveralls"
   - "pip install -e .[test]"
 script: 
   - py.test --cov cligj --cov-report term-missing

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 cligj
 ======
 
+.. image:: https://github.com/mapbox/cligj/actions/workflows/python-package.yml/badge.svg
+   :alt: Python Workflow
+   :target: https://github.com/mapbox/cligj/actions/workflows/python-package.yml
+   
 .. image:: https://app.travis-ci.com/mapbox/cligj.svg?branch=master
     :target: https://app.travis-ci.com/mapbox/cligj
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with codecs_open('README.rst', encoding='utf-8') as f:
 setup(
     name="cligj",
     version=version,
-    description=u"Click params for commmand line interfaces to GeoJSON",
+    description=u"Click params for command line interfaces to GeoJSON",
     long_description=long_description,
     classifiers=[],
     keywords="",


### PR DESCRIPTION
Remove Python 3.7

Due to compatibility issues that are not caused by the project
we skip 3.7
ref : https://github.com/TheKevJames/coveralls-python/pull/337