### PR TITLE
deps: Remove python version upper constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=find_packages(exclude=["ez_setup", "examples", "tests"]),
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, <4",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*",
     install_requires=["click >= 4.0"],
     extras_require={"test": ["pytest-cov"],},
 )


### PR DESCRIPTION
This constraint, forces all downstream poetry users to also pin the upper python version which depending on the use case might not be desirable.

This PR removes the constraint.

Fixes #43